### PR TITLE
Fixed working directory overwriting when aborted

### DIFF
--- a/create-sequence.js
+++ b/create-sequence.js
@@ -8,7 +8,7 @@ const init = require("init-package-json")
 const fs = require("fs/promises")
 const path = require("path")
 
-const templateName = process.argv[2] || "default"
+const templateName = process.argv[2] || "js-simple"
 
 const exists = async (path) => {
   return fs.access(path)

--- a/create-sequence.js
+++ b/create-sequence.js
@@ -8,7 +8,7 @@ const init = require("init-package-json")
 const fs = require("fs/promises")
 const path = require("path")
 
-const templateName = process.argv[2] || "js-simple"
+const templateName = process.argv[2] || "py-simple"
 
 const exists = async (path) => {
   return fs.access(path)


### PR DESCRIPTION
Old behaviour:
-If working directory contains user package.json final package.json is merge of template and local package.json
-If user aborts creation of package.json, in prompt template files are still copied to location and overwrites user files
-Any call to script will change working directory

New behaviour:
-package.json is result of only template and prompt questions
-canceling creation in any moment before accepting package.json in prompt doesn't cause any changes to user working location
-if package.json exists in working directory process aborts
-added logs i.e.(...succesfully created, ...initialization canceled) to improve UX

To run:
node ./create-sequence (defaults to py-simple)
node ./create-sequence py-simple
node ./create-sequence js-simple
node ./create-sequence ts-simple
